### PR TITLE
Add partial support for Cosmos DB, including ability to read and update

### DIFF
--- a/src/ShapeStore/Domain/Entities/Location.cs
+++ b/src/ShapeStore/Domain/Entities/Location.cs
@@ -1,6 +1,7 @@
 ﻿#nullable disable
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Converters;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
 namespace ShapeStore.Domain.Entities;
 

--- a/src/ShapeStore/Infrastructure/Configuration/StoreOptions.cs
+++ b/src/ShapeStore/Infrastructure/Configuration/StoreOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace ShapeStore.Infrastructure.Configuration
+{
+    public class StoreOptions
+    {
+        public const string StoreSettignsSection = "StoreSettings";
+        public string StoreType { get; set; } = "sql"; // sql, cosmos, postgresql
+        public string DatabaseName { get; set; } = ""; // if needed and not contained in connection string
+    }
+}

--- a/src/ShapeStore/Infrastructure/DbContexts/IModelCreator.cs
+++ b/src/ShapeStore/Infrastructure/DbContexts/IModelCreator.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace ShapeStore.Infrastructure.DbContexts
+{
+    public interface IModelCreator
+    {
+        void OnModelCreating(ModelBuilder modelBuilder);
+    }
+}

--- a/src/ShapeStore/Infrastructure/DbContexts/NoSqlModelCreator.cs
+++ b/src/ShapeStore/Infrastructure/DbContexts/NoSqlModelCreator.cs
@@ -1,0 +1,35 @@
+﻿#nullable disable
+using Microsoft.EntityFrameworkCore;
+using ShapeStore.Domain.Entities;
+
+namespace ShapeStore.Infrastructure.DbContexts;
+
+// model creator class for NoSQL / document data store
+public class NoSqlModelCreator : IModelCreator
+{ 
+    // adopt the .NET 9 convention to avoid need to update later
+    private const string _discriminatorColumnName = "$type";
+    public void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultContainer("locations");
+
+        // categories of locations.  these may vary based on the application
+        modelBuilder.Entity<Category>(entity =>
+        {
+            entity.HasDiscriminator<string>(_discriminatorColumnName)
+                .HasValue<Category>("category");
+        });
+        // available icons
+        modelBuilder.Entity<Icon>(entity =>
+        {
+            entity.HasDiscriminator<string>(_discriminatorColumnName)
+                .HasValue<Icon>("icon");
+        });
+        // one location including a shape representing its location or boundary
+        modelBuilder.Entity<Location>(entity =>
+        {
+            entity.HasDiscriminator<string>(_discriminatorColumnName)
+                .HasValue<Location>("location");
+        });
+    }
+}

--- a/src/ShapeStore/Infrastructure/DbContexts/SqlModelCreator.cs
+++ b/src/ShapeStore/Infrastructure/DbContexts/SqlModelCreator.cs
@@ -1,0 +1,59 @@
+﻿#nullable disable
+using Microsoft.EntityFrameworkCore;
+using ShapeStore.Domain.Entities;
+
+namespace ShapeStore.Infrastructure.DbContexts;
+
+// model creator class for relational databases
+public class SqlModelCreator : IModelCreator
+{
+    public void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // categories of locations.  these may vary based on the application
+        modelBuilder.Entity<Category>(entity =>
+        {
+            entity.ToTable("Category");
+
+            entity.Property(e => e.Description).HasMaxLength(256);
+            entity.Property(e => e.Name)
+                .IsRequired()
+                .HasMaxLength(50);
+
+            entity.HasOne(d => d.Icon).WithMany(p => p.Categories)
+                .HasForeignKey(d => d.IconId)
+                .HasConstraintName("FK_Category_Icon");
+        });
+        // available icons
+        modelBuilder.Entity<Icon>(entity =>
+        {
+            entity.ToTable("Icon");
+
+            entity.Property(e => e.IconId).ValueGeneratedNever();
+            entity.Property(e => e.Description).HasMaxLength(256);
+            entity.Property(e => e.Name)
+                .IsRequired()
+                .HasMaxLength(50);
+        });
+        // one location including a shape representing its location or boundary
+        modelBuilder.Entity<Location>(entity =>
+        {
+            entity.ToTable("Location");
+
+            entity.Property(e => e.Address1).HasMaxLength(256);
+            entity.Property(e => e.Address2).HasMaxLength(256);
+            entity.Property(e => e.City).HasMaxLength(96);
+            entity.Property(e => e.Name).HasMaxLength(256);
+            entity.Property(e => e.Notes).HasMaxLength(1024);
+            entity.Property(e => e.Phone).HasMaxLength(20);
+            entity.Property(e => e.Phone2).HasMaxLength(50);
+            entity.Property(e => e.PostalCode).HasMaxLength(16);
+            entity.Property(e => e.State).HasMaxLength(50);
+            entity.Property(e => e.Url).HasMaxLength(512);
+            entity.Property(e => e.Geometry).HasColumnType("geography");
+
+            entity.HasOne(d => d.Category).WithMany(p => p.Locations)
+                .HasForeignKey(d => d.CategoryId)
+                .HasConstraintName("FK_Location_Category");
+        });
+    }
+}

--- a/src/ShapeStore/Infrastructure/Repositories/LocationRepository.cs
+++ b/src/ShapeStore/Infrastructure/Repositories/LocationRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using ShapeStore.Application.Interfaces;
 using ShapeStore.Domain.Entities;
+using ShapeStore.Infrastructure.DbContexts;
 
 namespace ShapeStore.Infrastructure.Repositories
 {

--- a/src/ShapeStore/Infrastructure/ShapeStoreContext.cs
+++ b/src/ShapeStore/Infrastructure/ShapeStoreContext.cs
@@ -1,14 +1,20 @@
 ﻿#nullable disable
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using ShapeStore.Domain.Entities;
+using ShapeStore.Infrastructure.Configuration;
+using ShapeStore.Infrastructure.DbContexts;
 
 namespace ShapeStore.Infrastructure;
 
 public partial class ShapeStoreContext : DbContext
 {
-    public ShapeStoreContext(DbContextOptions<ShapeStoreContext> options)
+    private readonly StoreOptions _storeOptions;
+
+    public ShapeStoreContext(DbContextOptions<ShapeStoreContext> options, IOptions<StoreOptions> storeOptions)
         : base(options)
     {
+        _storeOptions = storeOptions.Value;
     }
 
     public virtual DbSet<Category> Categories { get; set; }
@@ -16,57 +22,20 @@ public partial class ShapeStoreContext : DbContext
     public virtual DbSet<Icon> Icons { get; set; }
 
     public virtual DbSet<Location> Locations { get; set; }
-
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        // categories of locations.  these may vary based on the application
-        modelBuilder.Entity<Category>(entity =>
-        {
-            entity.ToTable("Category");
-
-            entity.Property(e => e.Description).HasMaxLength(256);
-            entity.Property(e => e.Name)
-                .IsRequired()
-                .HasMaxLength(50);
-
-            entity.HasOne(d => d.Icon).WithMany(p => p.Categories)
-                .HasForeignKey(d => d.IconId)
-                .HasConstraintName("FK_Category_Icon");
-        });
-        // available icons
-        modelBuilder.Entity<Icon>(entity =>
-        {
-            entity.ToTable("Icon");
-
-            entity.Property(e => e.IconId).ValueGeneratedNever();
-            entity.Property(e => e.Description).HasMaxLength(256);
-            entity.Property(e => e.Name)
-                .IsRequired()
-                .HasMaxLength(50);
-        });
-        // one location including a shape representing its location or boundary
-        modelBuilder.Entity<Location>(entity =>
-        {
-            entity.ToTable("Location");
-
-            entity.Property(e => e.Address1).HasMaxLength(256);
-            entity.Property(e => e.Address2).HasMaxLength(256);
-            entity.Property(e => e.City).HasMaxLength(96);
-            entity.Property(e => e.Name).HasMaxLength(256);
-            entity.Property(e => e.Notes).HasMaxLength(1024);
-            entity.Property(e => e.Phone).HasMaxLength(20);
-            entity.Property(e => e.Phone2).HasMaxLength(50);
-            entity.Property(e => e.PostalCode).HasMaxLength(16);
-            entity.Property(e => e.State).HasMaxLength(50);
-            entity.Property(e => e.Url).HasMaxLength(512);
-            entity.Property(e => e.Geometry).HasColumnType("geography");
-
-            entity.HasOne(d => d.Category).WithMany(p => p.Locations)
-                .HasForeignKey(d => d.CategoryId)
-                .HasConstraintName("FK_Location_Category");
-        });
+        GetModelCreator().OnModelCreating(modelBuilder);
 
         OnModelCreatingPartial(modelBuilder);
     }
+    protected IModelCreator GetModelCreator()
+    {
+        return _storeOptions.StoreType switch
+        {
+            "cosmos" => new NoSqlModelCreator(),
+            _ => new SqlModelCreator()
+        };
+    }
+
     partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
 }

--- a/src/ShapeStore/Infrastructure/ShapeStoreExtensions.cs
+++ b/src/ShapeStore/Infrastructure/ShapeStoreExtensions.cs
@@ -3,18 +3,53 @@ using ShapeStore.Application.Interfaces;
 using ShapeStore.Application.Services;
 using ShapeStore.Domain.Entities;
 using ShapeStore.Infrastructure.Repositories;
+using ShapeStore.Infrastructure.Configuration;
 using NetTopologySuite.IO.Converters;
+using ShapeStore.Infrastructure.DbContexts;
+using Microsoft.AspNetCore.OutputCaching;
 
 namespace ShapeStore.Infrastructure
 {
     public static class ShapeStoreExtensions
     {
+        public static StoreOptions GetStoreOptions(ConfigurationManager configurationManager)
+        {
+            StoreOptions storeOptions = new();
+            configurationManager.GetSection($"{StoreOptions.StoreSettignsSection}")
+                .Bind(storeOptions);
+            return storeOptions;
+        }
         public static void AddShapeStore(this IServiceCollection services,
             ConfigurationManager configurationManager)
         {
-            services.AddDbContext<ShapeStoreContext>(
-                options => options.UseSqlServer(configurationManager.GetConnectionString("ShapeConnection"),
-                    sqlServerOptions => sqlServerOptions.UseNetTopologySuite()));
+            services.Configure<StoreOptions>(
+                configurationManager.GetSection($"{StoreOptions.StoreSettignsSection}"));
+
+            StoreOptions? storsSettings = GetStoreOptions(configurationManager);
+            string storeType = storsSettings?.StoreType ?? "sql";
+            string databaseName = storsSettings?.DatabaseName ?? "";
+
+            switch (storeType)
+            {
+                case "sql":
+                    services.AddDbContext<ShapeStoreContext>(
+                        options => options.UseSqlServer(configurationManager.GetConnectionString("ShapeConnection"),
+                            sqlServerOptions => sqlServerOptions.UseNetTopologySuite()));
+                    break;
+                case "cosmos":
+                    string connectionString = configurationManager.GetConnectionString("ShapeConnection") ?? "";
+                    services.AddDbContext<ShapeStoreContext>(
+                        options => options.UseCosmos(
+                            connectionString,
+                            databaseName: databaseName,
+                              cosmosOptionsAction: options =>
+                              {
+                                  options.ConnectionMode(Microsoft.Azure.Cosmos.ConnectionMode.Direct);
+                                  options.MaxRequestsPerTcpConnection(16);
+                                  options.MaxTcpConnectionsPerEndpoint(32);
+                              }));
+                    break;
+            }
 
             services.AddScoped(typeof(ILocationRepository), typeof(LocationRepository));
             services.AddScoped(typeof(IRepository<>), typeof(Repository<>));

--- a/src/ShapeStore/ShapeStore.csproj
+++ b/src/ShapeStore/ShapeStore.csproj
@@ -13,16 +13,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.Result" Version="9.1.0" />
-    <PackageReference Include="Ardalis.Result.AspNetCore" Version="9.1.0" />
-    <PackageReference Include="Ardalis.Result.FluentValidation" Version="9.1.0" />
-    <PackageReference Include="FluentValidation" Version="11.9.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="8.0.8" />
+    <PackageReference Include="Ardalis.Result" Version="10.0.0" />
+    <PackageReference Include="Ardalis.Result.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Ardalis.Result.FluentValidation" Version="10.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="8.0.10" />
     <PackageReference Include="NetTopologySuite" Version="2.5.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/ShapeStore/appsettings.json
+++ b/src/ShapeStore/appsettings.json
@@ -8,5 +8,9 @@
   "ConnectionStrings": {
     "ShapeConnection": "" // store in secure place
   },
+  "StoreSettings": {
+    "StoreType": "sql", // sql or cosmos
+    "DatabaseName": "shapedatabasename"
+  },
   "AllowedHosts": "*"
 }

--- a/src/ShapeStore/libman.json
+++ b/src/ShapeStore/libman.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "defaultProvider": "cdnjs",
+  "libraries": []
+}


### PR DESCRIPTION
properties other than the spatial / GeoJSON property.  EF Core has some support for Cosmos but relies on NetTopologySuite for spatial support, and NTS does not support spatial properties in Cosmos.